### PR TITLE
fix(pinblock): bounds-check PIN length on Decode; add fuzzers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,40 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test ./formats/... -fuzz FuzzISO0EncodeDecode -fuzztime 10m"
+          - "go test ./formats/... -fuzz FuzzDecodeOnly -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/formats/eci.go
+++ b/formats/eci.go
@@ -103,10 +103,7 @@ func (i *eciObject) Decode(pinBlock, account string) (string, error) {
 
 	pinLength := 4
 	remainder := pinBlock
-	if i.getVersion() == eci2Version {
-		pinLength = 4
-		remainder = pinBlock
-	} else {
+	if i.getVersion() != eci2Version {
 		var rest string
 		_, err := fmt.Sscanf(pinBlock, "%01d%s", &pinLength, &rest)
 		if err != nil {

--- a/formats/eci.go
+++ b/formats/eci.go
@@ -102,16 +102,24 @@ func (i *eciObject) Decode(pinBlock, account string) (string, error) {
 	}
 
 	pinLength := 4
+	remainder := pinBlock
 	if i.getVersion() == eci2Version {
 		pinLength = 4
+		remainder = pinBlock
 	} else {
-		_, err := fmt.Sscanf(pinBlock, "%01d%s", &pinLength, &pinBlock)
+		var rest string
+		_, err := fmt.Sscanf(pinBlock, "%01d%s", &pinLength, &rest)
 		if err != nil {
 			return "", fmt.Errorf("unable to parse pin block")
 		}
 		if pinLength > 6 || pinLength < 4 {
 			return "", fmt.Errorf("unable to parse pin block")
 		}
+		remainder = rest
+	}
+
+	if pinLength > len(remainder) {
+		return "", fmt.Errorf("pin length %d exceeds remaining block length %d", pinLength, len(remainder))
 	}
 
 	// write decode information
@@ -121,8 +129,8 @@ func (i *eciObject) Decode(pinBlock, account string) (string, error) {
 		fmt.Fprintf(tw, "%s\n", strings.Repeat("*", 36))
 		fmt.Fprintf(tw, "Formatted PIN block\t: %s\n", strings.ToUpper(pinBlock))
 		var pad string
-		if len(pinBlock) > pinLength {
-			pad = pinBlock[pinLength:]
+		if len(remainder) > pinLength {
+			pad = remainder[pinLength:]
 		}
 		if pad == "" {
 			fmt.Fprintf(tw, "PAD\t: N/A\n")
@@ -131,9 +139,9 @@ func (i *eciObject) Decode(pinBlock, account string) (string, error) {
 		}
 		fmt.Fprintf(tw, "Format\t: %s\n", i.format)
 		fmt.Fprintf(tw, "%s\n", strings.Repeat("-", 36))
-		fmt.Fprintf(tw, "Decoded PIN\t: %s\n", pinBlock[:pinLength])
+		fmt.Fprintf(tw, "Decoded PIN\t: %s\n", remainder[:pinLength])
 		tw.Write([]byte("\n"))
 	}
 
-	return pinBlock[:pinLength], nil
+	return remainder[:pinLength], nil
 }

--- a/formats/eci_test.go
+++ b/formats/eci_test.go
@@ -137,14 +137,14 @@ PIN     : 1234`
 
 		expectedOutput := `PIN block decode operation finished
 ************************************
-Formatted PIN block  : 123456789012AAA
+Formatted PIN block  : 6123456789012AAA
 PAD                  : 789012AAA
 Format               : ECI-3
 ------------------------------------
 Decoded PIN  : 123456
 
 `
-		require.Equal(t, out.String(), expectedOutput)
+		require.Equal(t, expectedOutput, out.String())
 	})
 }
 
@@ -206,13 +206,13 @@ PIN     : 1234`
 
 		expectedOutput := `PIN block decode operation finished
 ************************************
-Formatted PIN block  : 123456789012222
+Formatted PIN block  : 6123456789012222
 PAD                  : 789012222
 Format               : VISA-2
 ------------------------------------
 Decoded PIN  : 123456
 
 `
-		require.Equal(t, out.String(), expectedOutput)
+		require.Equal(t, expectedOutput, out.String())
 	})
 }

--- a/formats/fuzz_regression_test.go
+++ b/formats/fuzz_regression_test.go
@@ -1,0 +1,31 @@
+package formats_test
+
+import (
+	"testing"
+
+	"github.com/moov-io/pinblock/formats"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode_InvalidPinLengthNoPanic(t *testing.T) {
+	// Previously paniced on ISO-0 when pin length nibble exceeded block
+	require.NotPanics(t, func() {
+		_, _ = formats.NewISO0().Decode("0A00000000000000", "0000000000000")
+	})
+	// ECI/VISA2 with spaces / short remainder after length digit
+	require.NotPanics(t, func() {
+		for _, ctor := range []func() formats.Format{
+			formats.NewISO0, formats.NewISO1, formats.NewISO3,
+			formats.NewECI1, formats.NewECI2, formats.NewECI3, formats.NewECI4,
+			formats.NewVISA1, formats.NewVISA2, formats.NewVISA3, formats.NewVISA4,
+			formats.NewOEM1, formats.NewANSIX98,
+		} {
+			block, err := ctor().Encode("00 0", "0")
+			if err != nil {
+				_, _ = ctor().Decode("0A00000000000000", "0000000000000")
+				continue
+			}
+			_, _ = ctor().Decode(block, "0")
+		}
+	})
+}

--- a/formats/fuzz_test.go
+++ b/formats/fuzz_test.go
@@ -1,0 +1,75 @@
+package formats_test
+
+import (
+	"testing"
+
+	"github.com/moov-io/pinblock/formats"
+)
+
+func FuzzISO0EncodeDecode(f *testing.F) {
+	// Real test vectors from iso0_test.go
+	seeds := []struct{ pin, pan string }{
+		{"1234", "5432101234567891"},
+		{"123456789012", "4000000000000002"},
+		{"9", "4111111111111111"},
+		{"", ""},
+		{"1234", "123"},
+		{"abcdef", "5432101234567891"},
+	}
+	for _, s := range seeds {
+		f.Add(s.pin, s.pan)
+	}
+
+	f.Fuzz(func(t *testing.T, pin, pan string) {
+		if len(pin) > 32 || len(pan) > 32 {
+			t.Skip()
+		}
+
+		for _, ctor := range []func() formats.Format{
+			formats.NewISO0,
+			formats.NewISO1,
+			formats.NewISO2,
+			formats.NewISO3,
+			formats.NewANSIX98,
+			formats.NewOEM1,
+			formats.NewECI1,
+			formats.NewECI2,
+			formats.NewECI3,
+			formats.NewECI4,
+			formats.NewVISA1,
+			formats.NewVISA2,
+			formats.NewVISA3,
+			formats.NewVISA4,
+		} {
+			fmtter := ctor()
+			block, err := fmtter.Encode(pin, pan)
+			if err != nil {
+				continue
+			}
+			_, _ = fmtter.Decode(block, pan)
+		}
+	})
+}
+
+func FuzzDecodeOnly(f *testing.F) {
+	f.Add("041215FEDCBA9876", "5432101234567891")
+	f.Add("", "")
+	f.Add("0000000000000000", "4111111111111111")
+	f.Add("FFFFFFFFFFFFFFFF", "4000000000000002")
+
+	f.Fuzz(func(t *testing.T, block, pan string) {
+		if len(block) > 64 || len(pan) > 32 {
+			t.Skip()
+		}
+
+		for _, ctor := range []func() formats.Format{
+			formats.NewISO0,
+			formats.NewISO1,
+			formats.NewISO3,
+			formats.NewANSIX98,
+			formats.NewVISA1,
+		} {
+			_, _ = ctor().Decode(block, pan)
+		}
+	})
+}

--- a/formats/iso0.go
+++ b/formats/iso0.go
@@ -112,6 +112,9 @@ func (i *iso0Object) Decode(pinBlock, account string) (string, error) {
 
 	// decodedBlock should start with 0, then has length of pin, then has pin, then has F until 16 characters
 	pinLength := int(decodedBlock[1] - '0')
+	if pinLength < 4 || pinLength > 12 || 2+pinLength > len(decodedBlock) {
+		return "", fmt.Errorf("invalid pin length %d", pinLength)
+	}
 	pin := decodedBlock[2 : 2+pinLength]
 
 	// write decode information

--- a/formats/iso4.go
+++ b/formats/iso4.go
@@ -162,9 +162,15 @@ func (i *iso4Object) Decode(pinBlock, account string) (string, error) {
 	plainPinBlock := hex.EncodeToString(rawPinBlock)
 
 	// rawPinBlock should now be the original pinBlock, we'll parse it to get the PIN.
+	if len(plainPinBlock) < 2 {
+		return "", fmt.Errorf("plain pin block too short")
+	}
 	pinLength, err := strconv.ParseInt(string(plainPinBlock[1]), 16, 64)
 	if err != nil {
 		return "", fmt.Errorf("parsing pin length: %w", err)
+	}
+	if pinLength < 4 || pinLength > 12 || 2+int(pinLength) > len(plainPinBlock) {
+		return "", fmt.Errorf("invalid pin length %d", pinLength)
 	}
 
 	pin := string(plainPinBlock[2 : 2+pinLength])

--- a/formats/oem.go
+++ b/formats/oem.go
@@ -87,8 +87,11 @@ func (i *oemObject) Decode(pinBlock, account string) (string, error) {
 		return "", fmt.Errorf("pin block must be 16 characters")
 	}
 
-	// getting pin length
+	// getting pin length (characters before the padding digit)
 	pinLength := len(strings.ReplaceAll(pinBlock, pinBlock[len(pinBlock)-1:], ""))
+	if pinLength <= 0 || pinLength > len(pinBlock) {
+		return "", fmt.Errorf("invalid pin length %d", pinLength)
+	}
 
 	// write decode information
 	if i.debugWriter != nil {

--- a/formats/testdata/fuzz/FuzzDecodeOnly/1401f090599c58fc
+++ b/formats/testdata/fuzz/FuzzDecodeOnly/1401f090599c58fc
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0A00000000000000")
+string("0000000000000")

--- a/formats/testdata/fuzz/FuzzISO0EncodeDecode/65c1542bccb8c9dd
+++ b/formats/testdata/fuzz/FuzzISO0EncodeDecode/65c1542bccb8c9dd
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("00 0")
+string("0")


### PR DESCRIPTION
## Summary
ISO-0/ISO-4/ECI/OEM Decode could panic when the decoded PIN length nibble exceeded the remaining block (or when Sscanf truncated on spaces). Validate lengths before slicing, update ECI debug expectations, and add encode/decode fuzzers plus a regression test.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing